### PR TITLE
Correctly determine the target directory when project inside workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Make sure you are using the latest version of stable rust by running `rustup upd
 
 On Linux you need to first run:
 
-`sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev`
+`sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev jq`
 
 On Fedora Rawhide you need to run:
 
-`dnf install clang clang-devel clang-tools-extra speech-dispatcher-devel libxkbcommon-devel pkg-config openssl-devel`
+`dnf install clang clang-devel clang-tools-extra speech-dispatcher-devel libxkbcommon-devel pkg-config openssl-devel jq`
 
 ### Compiling for the web
 

--- a/build_web.sh
+++ b/build_web.sh
@@ -18,10 +18,12 @@ rm -f docs/${CRATE_NAME_SNAKE_CASE}_bg.wasm
 echo "Building rust…"
 BUILD=release
 cargo build --release -p ${CRATE_NAME} --lib --target wasm32-unknown-unknown
+# Get the output directory (in the workspace it is in another location)
+TARGET=`cargo metadata --format-version=1 | jq --raw-output .target_directory`
 
 echo "Generating JS bindings for wasm…"
 TARGET_NAME="${CRATE_NAME_SNAKE_CASE}.wasm"
-wasm-bindgen "target/wasm32-unknown-unknown/${BUILD}/${TARGET_NAME}" \
+wasm-bindgen "${TARGET}/wasm32-unknown-unknown/${BUILD}/${TARGET_NAME}" \
   --out-dir docs --no-modules --no-typescript
 
 # to get wasm-opt:  apt/brew/dnf install binaryen


### PR DESCRIPTION
Use [`cargo metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html) to get the actual `target` directory and `jq` to extract directory from returned JSON.

https://packages.fedoraproject.org/pkgs/jq/ tells that Fedora package is named `jq` but I haven't check that, I have only Ubuntu.