### PR TITLE
Use shell best practices in build_web.sh

### DIFF
--- a/build_web.sh
+++ b/build_web.sh
@@ -47,14 +47,14 @@ BUILD=release
 cargo build -p "${CRATE_NAME}" --release --lib --target wasm32-unknown-unknown
 
 # Get the output directory (in the workspace it is in another location)
-TARGET=`cargo metadata --format-version=1 | jq --raw-output .target_directory`
+TARGET=$(cargo metadata --format-version=1 | jq --raw-output .target_directory)
 
 echo "Generating JS bindings for wasm…"
 TARGET_NAME="${CRATE_NAME_SNAKE_CASE}.wasm"
 wasm-bindgen "${TARGET}/wasm32-unknown-unknown/${BUILD}/${TARGET_NAME}" \
   --out-dir docs --no-modules --no-typescript
 
-if [ "${FAST}" = false ]; then
+if [[ "${FAST}" == false ]]; then
   echo "Optimizing wasm…"
   # to get wasm-opt:  apt/brew/dnf install binaryen
   wasm-opt "docs/${CRATE_NAME}_bg.wasm" -O2 --fast-math -o "docs/${CRATE_NAME}_bg.wasm" # add -g to get debug symbols
@@ -62,7 +62,7 @@ fi
 
 echo "Finished: docs/${CRATE_NAME_SNAKE_CASE}.wasm"
 
-if [ "${OPEN}" = true ]; then
+if [[ "${OPEN}" == true ]]; then
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Linux, ex: Fedora
     xdg-open http://localhost:8080/index.html

--- a/build_web.sh
+++ b/build_web.sh
@@ -40,11 +40,11 @@ CRATE_NAME_SNAKE_CASE="${CRATE_NAME//-/_}" # for those who name crates with-keba
 export RUSTFLAGS=--cfg=web_sys_unstable_apis
 
 # Clear output from old stuff:
-rm -f docs/${CRATE_NAME_SNAKE_CASE}_bg.wasm
+rm -f "docs/${CRATE_NAME_SNAKE_CASE}_bg.wasm"
 
 echo "Building rust…"
 BUILD=release
-cargo build -p ${CRATE_NAME} --release --lib --target wasm32-unknown-unknown
+cargo build -p "${CRATE_NAME}" --release --lib --target wasm32-unknown-unknown
 
 # Get the output directory (in the workspace it is in another location)
 TARGET=`cargo metadata --format-version=1 | jq --raw-output .target_directory`
@@ -57,7 +57,7 @@ wasm-bindgen "${TARGET}/wasm32-unknown-unknown/${BUILD}/${TARGET_NAME}" \
 if [ "${FAST}" = false ]; then
   echo "Optimizing wasm…"
   # to get wasm-opt:  apt/brew/dnf install binaryen
-  wasm-opt docs/${CRATE_NAME}_bg.wasm -O2 --fast-math -o docs/${CRATE_NAME}_bg.wasm # add -g to get debug symbols
+  wasm-opt "docs/${CRATE_NAME}_bg.wasm" -O2 --fast-math -o "docs/${CRATE_NAME}_bg.wasm" # add -g to get debug symbols
 fi
 
 echo "Finished: docs/${CRATE_NAME_SNAKE_CASE}.wasm"


### PR DESCRIPTION
- Quotes all shell variables to avoid expansion/wordsplitting (in the unlikely case a folder is named something like `ab*c` or `a -rf * bc`)
- Use `[[` consistently. Shell is already specified as bash, so this should be fine
- Use `$()` over ``