### PR TITLE
🚨 Fix compilation warning about bin name conflict.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "eframe_template"
+default-run = "eframe_template_bin"
 version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 edition = "2021"
 rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[[bin]]
+name = "eframe_template_bin"
+path = "src/main.rs"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Start by clicking "Use this template" at https://github.com/emilk/eframe_templat
 
 Change the name of the crate: Chose a good name for your project, and change the name to it in:
 * `Cargo.toml`
-    * Update the `name` and `authors`
+    * Change the `package.name` from `eframe_template` to `your_crate`
+    * Change the `package.authors`
+    * Change the `package.default-run` from `eframe_template_bin` to `your_crate_bin` (note the `_bin`!)
+    * Change the `bin.name` from `eframe_template_bin` to `your_crate_bin` (note the `_bin`!)
 * `main.rs`
 * `docs/index.html`
     * Change the `<title>`


### PR DESCRIPTION
Linked to #48 : it is simpler and more logical to rename binary than rename library 😉