### PR TITLE
Hide console window in release builds on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(debug_assertions), deny(warnings))] // Forbid warnings in release builds
 #![warn(clippy::all, rust_2018_idioms)]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] //Hide console window in release builds on Windows, this blocks stdout.
 
 // When compiling natively:
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
This hides the console window on Windows, its only enabled on release builds as you lose stdout when using it.