### PR TITLE
Update README.md to compile on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On Linux you need to first run:
 
 On Fedora Rawhide you need to run:
 
-`dnf install clang clang-devel clang-tools-extra speech-dispatcher-devel libxkbcommon-devel pkg-config openssl-devel libxcb-devel`
+`dnf install clang clang-devel clang-tools-extra speech-dispatcher-devel libxkbcommon-devel pkg-config openssl-devel libxcb-devel fontconfig-devel`
 
 ### Web Locally
 


### PR DESCRIPTION
Add fontconfig-devel installation on Fedora to README.md