### PR TITLE
add rust flags in cargo config for web-sys unstable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# clipboard api is still unstable, so web-sys requires the below flag to be passed for copy (ctrl + c) to work
+# https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
+# check status at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#browser_compatibility
+[build]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ You can compile your app to [WASM](https://en.wikipedia.org/wiki/WebAssembly) an
 
 We use [Trunk](https://trunkrs.dev/) to build for web target.
 1. Install Trunk with `cargo install --locked trunk`.
-2. Run `RUSTFLAGS="--cfg=web_sys_unstable_apis" trunk serve` to build and serve on `http://127.0.0.1:8080`. Trunk will rebuild automatically if you edit the project.
+2. Run `trunk serve` to build and serve on `http://127.0.0.1:8080`. Trunk will rebuild automatically if you edit the project.
 3. Open `http://127.0.0.1:8080/index.html#dev` in a browser. See the warning below.
 
 > `assets/sw.js` script will try to cache our app, and loads the cached version when it cannot connect to server allowing your app to work offline (like PWA).
 > appending `#dev` to `index.html` will skip this caching, allowing us to load the latest builds during development.
 
 ### Web Deploy
-1. Just run `RUSTFLAGS="--cfg=web_sys_unstable_apis" trunk build --release`.
+1. Just run `trunk build --release`.
 2. It will generate a `dist` directory as a "static html" website
 3. Upload the `dist` directory to any of the numerous free hosting websites including [GitHub Pages](https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).
 4. we already provide a workflow that auto-deploys our app to GitHub pages if you enable it.


### PR DESCRIPTION
Trunk hooks is not enough to set env vars, so we need to use this workaround for now. 

fortunately, rustc doesn't complain about random cfg flags which are not used, so this doesn't affect  desktop fortunately. 