### PR TITLE
Remove filehash setting from Trunk.toml

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,2 +1,1 @@
 [build]
-filehash = false


### PR DESCRIPTION
By default, Trunk uses infinite caching. Without a file hash, this makes it quite easy for users to see stale copies of an application. The file hash (Trunk's default setting) ensures that users always load the exact hashed version that corresponds to what is currently deployed.

See also: https://github.com/thedodd/trunk/blob/master/Trunk.toml#L12-L13

Let me just add: I'm not sure why the setting was added in the first place, because the `Trunk.toml` contained no comments. But I've been wondering why Trunk has such a horrible caching policy for several months without realizing that eframe_template was setting an (arguably bad) non-default setting here.