### PR TITLE
rustup 1.72 update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.65.0
+          toolchain: 1.72.0
           target: wasm32-unknown-unknown
           override: true
       - name: Download and install Trunk binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "eframe_template"
 version = "0.1.0"
 authors = ["Emil Ernerfeldt <emil.ernerfeldt@gmail.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.72"
 
 
 [dependencies]
 egui = "0.22.0"
 eframe = { version = "0.22.0", default-features = false, features = [
-    "accesskit",     # Make egui comptaible with screen readers. NOTE: adds a lot of dependencies.
+    "accesskit",     # Make egui compatible with screen readers. NOTE: adds a lot of dependencies.
     "default_fonts", # Embed the default egui fonts.
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".
     "persistence",   # Enable restoring app state when restarting the app.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.65.0"
+channel = "1.72.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Today I attempted to use the steps provided but failed, below the logs.
I upgraded to rustup 1.72 and everything is working fine so thought why
not provide a PR for it.

```shell
❯ cargo run --release
info: syncing channel updates for '1.65.0-x86_64-unknown-linux-gnu'
info: latest update on 2022-11-03, rust version 1.65.0 (897e37553 2022-11-02)
error: 'rustc' is not installed for the toolchain '1.65.0-x86_64-unknown-linux-gnu'
To install, run `rustup component add rustc --toolchain 1.65.0-x86_64-unknown-linux-gnu`
error: could not compile `egui_glow`
warning: build failed, waiting for other jobs to finish...
info: syncing channel updates for '1.65.0-x86_64-unknown-linux-gnu'
error: 'rustc' is not installed for the toolchain '1.65.0-x86_64-unknown-linux-gnu'
To install, run `rustup component add rustc --toolchain 1.65.0-x86_64-unknown-linux-gnu`
error: could not compile `atspi`
❯ rustup component add rustc --toolchain 1.65.0-x86_64-unknown-linux-gnu
error: Missing manifest in toolchain '1.65.0-x86_64-unknown-linux-gnu'
```

Note this could be related to my current machine setup. Since 1.65 is
from 10 months ago maybe it's being deprecated soon?