### PR TITLE
Reintroduce the loading spinner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
  "log",
  "serde",
  "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ env_logger = "0.10"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 
+# to access the DOM (to hide the loading text)
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3.4"
 
 [profile.release]
 opt-level = 2 # fast and small wasm

--- a/index.html
+++ b/index.html
@@ -119,6 +119,14 @@
 </head>
 
 <body>
+    <!-- the loading spinner will be removed in main.rs -->
+    <div class="centered" id="loading_text">
+        <p style="font-size:16px">
+            Loading…
+        </p>
+        <div class="lds-dual-ring"></div>
+    </div>
+
     <!-- The WASM code will resize the canvas dynamically -->
     <!-- the id is hardcoded in main.rs . so, make sure both match. -->
     <canvas id="the_canvas_id"></canvas>

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,5 +31,14 @@ fn main() {
             )
             .await
             .expect("failed to start eframe");
+        // Loading done - hide the loading text
+        let hide_loading_text_if_exists = || -> Option<()> {
+            web_sys::window()?
+                .document()?
+                .get_element_by_id("loading_text")?
+                .remove();
+            Some(())
+        };
+        let _ = hide_loading_text_if_exists();
     });
 }


### PR DESCRIPTION
## Context
The loading spinner (and loading text) were removed in d12c19da37de943d06703bec09613cf7121a70f9

## What changed
- now before the canvas is loaded a CSS loading spinner  with "Loading..." text is displayed
- the corresponding div is removed after loading completes

## How does it look
![image](https://github.com/emilk/eframe_template/assets/58441256/012ef5ec-3e3a-48ca-8971-5fb0afcad738)

## What exactly changed
- introduce dependency to `web-sys`
- add the removed `loading_text` div that shows the spinner and loading text during loading
- access the DOM (in `main.rs`) after the app has been loaded, and remove the spinner
  - if this operation fails (like when someone removes the div from `index.html` nothing happens)

## Discussion
  - I wanted to avoid dependency on `web-sys`, but, I don't see any other simple way to remove the spinner
  - Another idea I had was to do it straight from the  `js` side, however, I don't see a way to receive events from `WebRunner`