### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Make sure you are using the latest version of stable rust by running `rustup upd
 
 `cargo run --release`
 
-On Linux you need to first run:
+On Debian you need to first run:
 
 `sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev`
 


### PR DESCRIPTION
apt is not for all Linux distributions, only Debian based ones.
Based on <https://www.geeksforgeeks.org/apt-get-command-in-linux-with-examples/>

> ...APT (Advance Packaging Tool) system. Which manages packages for Debian-based Linux distributions.