### PR TITLE
Add note for Github Pages when initial branch is not named master

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ We use [Trunk](https://trunkrs.dev/) to build for web target.
 > To enable Github Pages, you need to go to Repository -> Settings -> Pages -> Source -> set to `gh-pages` branch and `/` (root).
 >
 > If `gh-pages` is not available in `Source`, just create and push a branch called `gh-pages` and it should be available.
+>
+> If you renamed the `master` branch to something else (say you re-initialized the repository with `main` as the initial branch), be sure to edit the github workflows `.github/workflows/pages.yml` file to reflect the change
+> ```yml
+> on:
+>   push:
+>     branches:
+>       - <branch name>
+> ```
 
 You can test the template app at <https://emilk.github.io/eframe_template/>.
 


### PR DESCRIPTION
For a little bit I was wondering why my deployment wasn't working, even though I changed very little. What happened was I deleted the `.git` folder and re-initialized the repository to clear commit history, but my default initial branch name is `main`. That broke the workflow because the `pages.yml` file by default uses the `master` branch
```yml
on:
  push:
    branches:
      - master
```
So this PR just adds a note in the README

I think it might also be worth considering adding a couple common branch names in the `pages.yml` file and have the user uncomment them (my eyes skipped over `master` since it looks similar to `main`)
```yml
# By default, runs if you push to master. keeps your deployed app in sync with master branch.
# If you renamed your initial branch name to something else, uncomment or change it below
on:
  push:
    branches:
      - master
#     - main
#     - trunk
```

