### PR TITLE
Provide starter code to set native icon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,11 @@ fn main() -> eframe::Result<()> {
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([400.0, 300.0])
-            .with_min_inner_size([300.0, 220.0]),
+            .with_min_inner_size([300.0, 220.0])
+            .with_icon(
+                eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
+                    .unwrap(),
+            ),
         ..Default::default()
     };
     eframe::run_native(

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ fn main() -> eframe::Result<()> {
             .with_inner_size([400.0, 300.0])
             .with_min_inner_size([300.0, 220.0])
             .with_icon(
+                // NOE: Adding an icon is optional
                 eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
                     .unwrap(),
             ),


### PR DESCRIPTION
Make it easier for new user to figure out how to set the icon for native apps. Would have liked to have used the same one as the web version but the favion is an ico file so used one of the other files I found in the assets folder. Not sure if I picked the most suitable one or if there was a way to do the same thing with an ico file.