### PR TITLE
Fix link to eframe

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -102,7 +102,7 @@ fn powered_by_egui_and_eframe(ui: &mut egui::Ui) {
         ui.label(" and ");
         ui.hyperlink_to(
             "eframe",
-            "https://github.com/emilk/egui/tree/main/crates/eframe",
+            "https://github.com/emilk/egui/tree/master/crates/eframe",
         );
         ui.label(".");
     });


### PR DESCRIPTION
The name of the primary branch in the upstream Repo is master not main. This PR fixes the link. Alternatively the name of the primary branch could just be changed to main as well.