### PR TITLE
Update CI deployment

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,17 +135,26 @@ jobs:
       run: echo "${{ matrix.TARGET }}"
 
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1.0.1
-      with:
-        toolchain: stable
-        target: ${{ matrix.TARGET }}
-        override: true
+    - name: Install build dependencies - Rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --profile default --target ${{ matrix.TARGET }} -y
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    - uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --verbose --release --target=${{ matrix.TARGET }}
+    # For linux, it's necessary to use cross from the git repository to avoid glibc problems
+    # Ref: https://github.com/cross-rs/cross/issues/1510
+    - name: Install cross for linux
+      if: contains(matrix.TARGET, 'linux')
+      run: |
+        cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7
+
+    - name: Install cross for mac and windows
+      if: ${{ !contains(matrix.TARGET, 'linux') }}
+      run: |
+        cargo install cross
+
+    - name: Build
+      run: |
+        cross build --verbose --release --target=${{ matrix.TARGET }}
 
     - name: Rename
       run: cp target/${{ matrix.TARGET }}/release/eframe_template${{ matrix.EXTENSION }} eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,13 +118,13 @@ jobs:
           TARGET: x86_64-apple-darwin
 
         - os: ubuntu-latest
-          TARGET: arm-unknown-linux-musleabihf
+          TARGET: aarch64-unknown-linux-gnu
 
         - os: ubuntu-latest
-          TARGET: armv7-unknown-linux-musleabihf
+          TARGET: armv7-unknown-linux-gnueabihf
 
         - os: ubuntu-latest
-          TARGET: x86_64-unknown-linux-musl
+          TARGET: x86_64-unknown-linux-gnu
 
         - os: windows-latest
           TARGET: x86_64-pc-windows-msvc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,9 +114,6 @@ jobs:
         - os: macos-latest
           TARGET: aarch64-apple-darwin
 
-        - os: macos-latest
-          TARGET: x86_64-apple-darwin
-
         - os: ubuntu-latest
           TARGET: aarch64-unknown-linux-gnu
 


### PR DESCRIPTION
At the moment, it appears that musl targets are not working: https://github.com/rust-windowing/winit/issues/1818
To use gnu, it's necessary to use glib 2.27, for that, cross need to be installed manually from development branch: https://github.com/cross-rs/cross/issues/1510 