### PR TITLE
Fix issues with runaway sizing of the canvas when rendering more complex things in egui

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,15 +60,28 @@
             width: 100%;
         }
 
-        /* Position canvas in center-top: */
+        /* This presumably fixes the issue described below.
+        But it also fixes an issue where, 
+        depending on what you render, the canvas may have sizing issues.
+
+        This issue lead to runaway resizing, as described here:
+        https://github.com/emilk/egui/discussions/4660
+        */
+        /* Position canvas in center-top.
+        This is rather arbitrarily chosen.
+        In particular, it seems like both Chromium and Firefox will still align
+        the canvas on the physical pixel grid, which is required to get
+        pixel-perfect (non-blurry) rendering in egui.
+        See https://github.com/emilk/egui/issues/4241 for more */
         canvas {
             margin-right: auto;
             margin-left: auto;
             display: block;
             position: absolute;
-            top: 0%;
-            left: 50%;
-            transform: translate(-50%, 0%);
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
         }
 
         .centered {


### PR DESCRIPTION
See https://github.com/emilk/egui/discussions/4660

IDK why the default render doesn't trigger this. Or precisely how this fixes it. But it does.