### PR TITLE
Fix `index.html` links to `manifest` and `apple-touch-icon`

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
     <link data-trunk rel="copy-file" href="assets/maskable_icon_x512.png" />
 
 
-    <link rel="manifest" href="manifest.json">
-    <link rel="apple-touch-icon" href="icon_ios_touch_192.png">
+    <link rel="manifest" href="assets/manifest.json">
+    <link rel="apple-touch-icon" href="assets/icon_ios_touch_192.png">
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#404040">
 


### PR DESCRIPTION
##  Bug: assets have incorrect paths

Proof:

```
git clone https://github.com/emilk/eframe_template.git && lychee .
```

```
  31/31 ━━━━━━━━━━━━━━━━━━━━ Finished extracting links                                                                                              Issues found in 1 input. Find details below.

[./eframe_template/index.html]:
✗ [ERR] file:///tmp/tmp.xuDXKdo4H8/eframe_template/icon_ios_touch_192.png | Failed: Cannot find file
✗ [ERR] file:///tmp/tmp.xuDXKdo4H8/eframe_template/manifest.json | Failed: Cannot find file

🔍 31 Total (in 0s) ✅ 29 OK 🚫 2 Errors

```


## Fix

change links to these assets


## Related to

- https://github.com/emilk/eframe_template/pull/137
- related to https://github.com/rerun-io/ewebsock/pull/38#issuecomment-2150380393