### PR TITLE
Fix assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,12 +17,12 @@
     <link data-trunk rel="icon" href="assets/favicon.ico">
 
 
-    <link data-trunk rel="copy-file" href="assets/sw.js" />
-    <link data-trunk rel="copy-file" href="assets/manifest.json" />
-    <link data-trunk rel="copy-file" href="assets/icon-1024.png" />
-    <link data-trunk rel="copy-file" href="assets/icon-256.png" />
-    <link data-trunk rel="copy-file" href="assets/icon_ios_touch_192.png" />
-    <link data-trunk rel="copy-file" href="assets/maskable_icon_x512.png" />
+    <link data-trunk rel="copy-file" href="assets/sw.js" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/manifest.json" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/icon-1024.png" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/icon-256.png" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/icon_ios_touch_192.png" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/maskable_icon_x512.png" data-target-path="assets"/>
 
 
     <link rel="manifest" href="assets/manifest.json">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link data-trunk rel="icon" href="assets/favicon.ico">
 
 
-    <link data-trunk rel="copy-file" href="assets/sw.js" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/sw.js"/>
     <link data-trunk rel="copy-file" href="assets/manifest.json" data-target-path="assets"/>
     <link data-trunk rel="copy-file" href="assets/icon-1024.png" data-target-path="assets"/>
     <link data-trunk rel="copy-file" href="assets/icon-256.png" data-target-path="assets"/>


### PR DESCRIPTION
Fix https://github.com/emilk/eframe_template/pull/142#issuecomment-2229172436

Note that only 

```
    <link rel="manifest" href="assets/manifest.json">
    <link rel="apple-touch-icon" href="assets/icon_ios_touch_192.png">
```

are really used in the final `index.html`