### PR TITLE
Update flake.nix to make wasm32_unknown_unknown available in nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,10 @@
         devShells.default = mkShell rec {
           buildInputs = [
             # Rust
-            rust-bin.stable.latest.default
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-std" ];
+              targets = [ "wasm32-unknown-unknown" ];
+            })
             trunk
 
             # misc. libraries


### PR DESCRIPTION
Compilation to the wasm target in a nix shell initiated by the contained nix flake did fail because the wasm target couldn't be found. Installing it manually with rustup did also not work due to conflicting rust installations.
This change to the nix flake makes it possible to compile it to the wasm target.
Nix beginner here, so maybe this can be done more elegantly 