### PR TITLE
Improve pipeline

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,14 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # repo checkout
-      - name: Setup toolchain for wasm
-        run: |
-          rustup update stable
-          rustup default stable
-          rustup set profile minimal
-          rustup target add wasm32-unknown-unknown
-      - name: Rust Cache # cache the rust build artefacts
-        uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@stable # get rust toolchain for wasm
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - name: Download and install Trunk binary
         run: wget -qO- https://github.com/thedodd/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - name: Build # build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request, workflow_dispatch]
+on: [
+  push, 
+  pull_request, 
+  workflow_dispatch,
+]
 
 name: CI
 
@@ -15,91 +19,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features
-
-  check_wasm:
-    name: Check wasm32
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --lib --target wasm32-unknown-unknown
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features --all-targets
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --lib
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # why is that here?
+      # - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
+      - run: cargo test --lib
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all
 
   trunk:
     name: trunk
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: 1.76.0
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
       - name: Download and install Trunk binary
         run: wget -qO- https://github.com/thedodd/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
       - name: Build
@@ -112,13 +77,19 @@ jobs:
       matrix:
         include:
         - os: macos-latest
+          # macos-latest seems to already run on arm64(=aarch64):
+          # https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
           TARGET: aarch64-apple-darwin
+
+        - os: macos-latest
+          TARGET: x86_64-apple-darwin
+          # even though the runner uses arm64, MacOS on arm64 seems to support building for amd64.
+          # which makes sense, would be bad for devs otherwise.
+          cross: false 
 
         - os: ubuntu-latest
           TARGET: aarch64-unknown-linux-gnu
-
-        - os: ubuntu-latest
-          TARGET: armv7-unknown-linux-gnueabihf
+          cross: true
 
         - os: ubuntu-latest
           TARGET: x86_64-unknown-linux-gnu
@@ -128,46 +99,57 @@ jobs:
           EXTENSION: .exe
 
     steps:
+    - name: Install cross
+      # Github doesnt have runners with exotic architectures (eg. arm64/aarch64 on anything but macos). 
+      # Thus we use cross.
+      # It's necessary to use an up-to-date cross from the git repository to avoid glibc problems on linux
+      # Ref: https://github.com/cross-rs/cross/issues/1510
+      if: matrix.cross
+      run: |
+        cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7
+
     - name: Building ${{ matrix.TARGET }}
       run: echo "${{ matrix.TARGET }}"
 
     - uses: actions/checkout@master
-    - name: Install build dependencies - Rustup
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --profile default --target ${{ matrix.TARGET }} -y
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-    # For linux, it's necessary to use cross from the git repository to avoid glibc problems
-    # Ref: https://github.com/cross-rs/cross/issues/1510
-    - name: Install cross for linux
-      if: contains(matrix.TARGET, 'linux')
-      run: |
-        cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.TARGET }}
 
-    - name: Install cross for mac and windows
-      if: ${{ !contains(matrix.TARGET, 'linux') }}
-      run: |
-        cargo install cross
+    - uses: Swatinem/rust-cache@v2
+      with:
+        # this is required to avoid failures due to caching of artifacts for different architectures
+        # The reason is the potential usage of cross.
+        # The cache checks the rustc host which doesn't record us targeting
+        # different architectures (and native) with cross on the generic ubuntu-latest.
+        key: ${{ matrix.TARGET }}
 
-    - name: Build
-      run: |
-        cross build --verbose --release --target=${{ matrix.TARGET }}
+    - if: ${{ !matrix.cross }}
+      name: Cargo Build
+      run: cargo build --verbose --release --target=${{ matrix.TARGET }}
+
+    - if: matrix.cross
+      name: Cross Build
+      run: cross build --verbose --release --target=${{ matrix.TARGET }}
 
     - name: Rename
-      run: cp target/${{ matrix.TARGET }}/release/eframe_template${{ matrix.EXTENSION }} eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
+      run: cp target/${{ matrix.TARGET }}/release/${{ github.event.repository.name }}${{ matrix.EXTENSION }} ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
 
     - uses: actions/upload-artifact@master
       with:
-        name: eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
-        path: eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
+        name: ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
+        path: ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
 
+    # this requires read-write permissions on the repo:
+    # https://github.com/svenstaro/upload-release-action/issues/70
     - uses: svenstaro/upload-release-action@v2
       name: Upload binaries to release
       if: ${{ github.event_name == 'push' }}
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
-        asset_name: eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
+        file: ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
+        asset_name: ${{ github.event.repository.name }}-${{ matrix.TARGET }}${{ matrix.EXTENSION }}
         tag: ${{ github.ref }}
         prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
         overwrite: true


### PR DESCRIPTION
This PR does a few things. If one of these makes you uncomfortable, feel free to ask me to remove them.

* It removes all traces of action-rs. #139 only removed one of these uses.
  * its using `dtolnay/rust-toolchain` to pull the toolchain.
  * this action doesn't support `minimal`, but honestly I also dont see the purpose of this since the action caches the toolchain, so removing this option speeds up previous tasks that used minimal, since they use the same toolchain as the other tasks 
* it removes wasm32 specific tasks where possible, e.g. its using `--all-targets` for cargo check
* it removes usage of cross where its not required, which should speed up the pipeline.
* it re-adds support for amd64 macos
* it uses `Swatinem/rust-cache` everywhere, not just to build pages. To do that properly in the build step, even with cross, it sets the key field
* it replaces mentions of `eframe_template`, which break the pipeline on anyone using this template, with `${{ github.event.repository.name }}`, which will work as long as the crate is renamed to its github repostory name.