### PR TITLE
Update `Cargo.lock` to allow compiling with `wgpu` backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1246,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005459a22af86adc706522d78d360101118e2638ec21df3852fcc626e0dbb212"
+checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
 dependencies = [
  "bitflags 2.6.0",
  "cfg_aliases",
@@ -1449,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2385,27 +2385,27 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2577,19 +2577,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2602,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2614,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2624,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2637,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wayland-backend"
@@ -2752,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3103,7 +3104,7 @@ dependencies = [
  "web-time",
  "windows-sys 0.48.0",
  "x11-dl",
- "x11rb 0.13.0",
+ "x11rb 0.13.1",
  "xkbcommon-dl",
 ]
 
@@ -3142,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname 0.4.3",
@@ -3152,7 +3153,7 @@ dependencies = [
  "libloading",
  "once_cell",
  "rustix 0.38.28",
- "x11rb-protocol 0.13.0",
+ "x11rb-protocol 0.13.1",
 ]
 
 [[package]]
@@ -3166,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ wasm-bindgen-futures = "0.4"
 
 # to access the DOM (to hide the loading text)
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3.4"
+# HACK: pin web-sys to <0.3.70 until a new `eframe` is released containing
+# the following PR: https://github.com/emilk/egui/pull/4980
+version = ">= 0.3.4, < 0.3.70"
 
 [profile.release]
 opt-level = 2 # fast and small wasm


### PR DESCRIPTION
This PR builds upon #159 and updates a few dependencies in `Cargo.lock` so that `eframe_template` can be compiled with the `wgpu` backend *without* removing and regenerating `Cargo.lock` from scratch.

Before this change, the following compile error occurs after switching from `glow` to `wgpu` backend:

```
ben@Bens-MacBook-Pro eframe_template % cargo check
error: failed to select a version for `termcolor`.
    ... required by package `naga v0.20.0`
    ... which satisfies dependency `naga = "^0.20.0"` of package `wgpu v0.20.1`
    ... which satisfies dependency `wgpu = "^0.20.0"` of package `eframe v0.28.0`
    ... which satisfies dependency `eframe = "^0.28"` (locked to 0.28.0) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`
versions that meet the requirements `^1.4.1` are: 1.4.1

all possible versions conflict with previously selected packages.

  previously selected package `termcolor v1.4.0`
    ... which satisfies dependency `termcolor = "^1.1.1"` (locked to 1.4.0) of package `env_logger v0.10.1`
    ... which satisfies dependency `env_logger = "^0.10"` (locked to 0.10.1) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`

failed to select a version for `termcolor` which could resolve this conflict
```

So I removed the `termcolor` entry from `Cargo.lock` and recompiled so that it would choose another version that works:

```
ben@Bens-MacBook-Pro eframe_template % cargo check
error: failed to select a version for `js-sys`.
    ... required by package `wgpu v0.20.1`
    ... which satisfies dependency `wgpu = "^0.20.0"` of package `eframe v0.28.0`
    ... which satisfies dependency `eframe = "^0.28"` (locked to 0.28.0) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`
versions that meet the requirements `^0.3.69` are: 0.3.70, 0.3.69

all possible versions conflict with previously selected packages.

  previously selected package `js-sys v0.3.66`
    ... which satisfies dependency `js-sys = "^0.3"` (locked to 0.3.66) of package `eframe v0.28.0`
    ... which satisfies dependency `eframe = "^0.28"` (locked to 0.28.0) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`

failed to select a version for `js-sys` which could resolve this conflict
```

Then I did the same for `js-sys` and recompiled:

```
ben@Bens-MacBook-Pro eframe_template % cargo check
error: failed to select a version for `wasm-bindgen-futures`.
    ... required by package `wgpu v0.20.1`
    ... which satisfies dependency `wgpu = "^0.20.0"` of package `eframe v0.28.0`
    ... which satisfies dependency `eframe = "^0.28"` (locked to 0.28.0) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`
versions that meet the requirements `^0.4.42` are: 0.4.43, 0.4.42

all possible versions conflict with previously selected packages.

  previously selected package `wasm-bindgen-futures v0.4.39`
    ... which satisfies dependency `wasm-bindgen-futures = "^0.4"` (locked to 0.4.39) of package `eframe_template v0.1.0 (/Users/ben/Documents/Fractals/eframe_template)`

failed to select a version for `wasm-bindgen-futures` which could resolve this conflict
```

And finally I did the same for `wasm-bindgen-futures` and recompiled, and it worked just fine.

I'm not sure if this is the proper way to resolve this issue. Let me know if I should have done something different.