### PR TITLE
fixed pkg-config package name in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
             # misc. libraries
             openssl
-            pkgconfig
+            pkg-config
 
             # GUI libs
             libxkbcommon


### PR DESCRIPTION
I was trying to set up an eframe project and the nix flake was not working. It worked after I fixed the package name like this.