### PR TITLE
fix PWA asset paths

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,1 +1,2 @@
 [build]
+filehash = false

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -3,18 +3,18 @@
   "short_name": "egui-template-pwa",
   "icons": [
     {
-      "src": "./icon-256.png",
+      "src": "./assets/icon-256.png",
       "sizes": "256x256",
       "type": "image/png"
     },
     {
-      "src": "./maskable_icon_x512.png",
+      "src": "./assets/maskable_icon_x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "./icon-1024.png",
+      "src": "./assets/icon-1024.png",
       "sizes": "1024x1024",
       "type": "image/png"
     }

--- a/index.html
+++ b/index.html
@@ -18,14 +18,14 @@
 
 
     <link data-trunk rel="copy-file" href="assets/sw.js"/>
-    <link data-trunk rel="copy-file" href="assets/manifest.json" data-target-path="assets"/>
+    <link data-trunk rel="copy-file" href="assets/manifest.json"/>
     <link data-trunk rel="copy-file" href="assets/icon-1024.png" data-target-path="assets"/>
     <link data-trunk rel="copy-file" href="assets/icon-256.png" data-target-path="assets"/>
     <link data-trunk rel="copy-file" href="assets/icon_ios_touch_192.png" data-target-path="assets"/>
     <link data-trunk rel="copy-file" href="assets/maskable_icon_x512.png" data-target-path="assets"/>
 
 
-    <link rel="manifest" href="assets/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon" href="assets/icon_ios_touch_192.png">
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#404040">


### PR DESCRIPTION
I noticed that  app shell isn't correctly cached by the service worker. Consequently PWA doesn't start correctly.

**Steps to reproduce**

- Build and serve the app: `trunk serve`
- Open app in the browser (chromium)
- Click "Install egui Template PWA"
- Close PWA
- Stop the server (trunk)
- Start previously installed PWA

**Proposed solution**

1. trunkrs adds hashes to the file names: `eframe_template-*`. This makes paths in `sw.js` under `filesToCache` invalid. I solved it by adding `filehash = false`. The other option could be generating `sw.js` with correct filenames in `post_build` hook of trunkrs.
2. I noticed that when `manifest.json` is served from `assets/`, then installed PWA starts from attempting to read `assets/index.html` from cache. The file is non-existing, so startup fails. I solved it by moving `manifest.json` to the root directory. This required relative paths in `manifest.json` to be updated.