### PR TITLE
docs: remove contradiction from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ The official egui docs are at <https://docs.rs/egui>. If you prefer watching a v
 
 ### Testing locally
 
-Make sure you are using the latest version of stable rust by running `rustup update`.
-
 `cargo run --release`
 
 On Linux you need to first run:


### PR DESCRIPTION
The line doesn't have the effect of using the most recent version because there is a toolchain file that tells cargo what version of rust to use.

Closes: https://github.com/emilk/eframe_template/issues/110