### PR TITLE
fix: restore missing x11 default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ eframe = { version = "0.30", default-features = false, features = [
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".
     "persistence",   # Enable restoring app state when restarting the app.
     "wayland",       # To support Linux (and CI)
+    "x11",           # To support older Linux distributions (restores one of the default features)
 ] }
 log = "0.4"
 


### PR DESCRIPTION
I wasn't sure if this feature was left out intentionally but realized that it is actually one of the [default features](https://github.com/emilk/egui/blob/a2afc8d092a4e3f0b17675b114db8fad08810947/crates/eframe/Cargo.toml#L41) so created this PR to add it as I suspect it was an oversight rather than a conscious decision.