### PR TITLE
Add comment for macOS users of fill_template.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Change the name of the crate: Choose a good name for your project, and change th
 
 Alternatively, you can run `fill_template.sh` which will ask for the needed names and email and perform the above patches for you. This is particularly useful if you clone this repository outside GitHub and hence cannot make use of its
 templating function.
-(macOS users will need to install GNU sed first for the script to work, if you're using Homebrew you can use `brew install gnu-sed`)
+(macOS users will need to install GNU sed first for the script to work, if you're using Homebrew you can use `brew install gnu-sed` and then add it to your path `PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH")
 ### Learning about egui
 
 `src/app.rs` contains a simple example app. This is just to give some inspiration - most of it can be removed if you like.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Change the name of the crate: Choose a good name for your project, and change th
 Alternatively, you can run `fill_template.sh` which will ask for the needed names and email and perform the above patches for you. This is particularly useful if you clone this repository outside GitHub and hence cannot make use of its
 templating function.
 (macOS users will need to install GNU sed first for the script to work, if you're using Homebrew you can use `brew install gnu-sed` and then add it to your path `PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH")
+
 ### Learning about egui
 
 `src/app.rs` contains a simple example app. This is just to give some inspiration - most of it can be removed if you like.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Change the name of the crate: Choose a good name for your project, and change th
 
 Alternatively, you can run `fill_template.sh` which will ask for the needed names and email and perform the above patches for you. This is particularly useful if you clone this repository outside GitHub and hence cannot make use of its
 templating function.
-
+(macOS users will need to install GNU sed first for the script to work, if you're using Homebrew you can use `brew install gnu-sed`)
 ### Learning about egui
 
 `src/app.rs` contains a simple example app. This is just to give some inspiration - most of it can be removed if you like.


### PR DESCRIPTION
Fixes [#164 ](https://github.com/emilk/eframe_template/issues/164) by adding a comment for macOS users in the README, as mentioned as a possible solution in the Issue.

However, I'm open to further ideas, right now this feels like the lowest hanging fruit.

Also, this explicitly refers to the homebrew method of adding gnused in macOS, while there are other ways too (like using nix for example), so should we keep it or should we let the user figure out how they wanna install gnused on their machine?