### PR TITLE
Fix typo in app.rs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,7 @@ impl TemplateApp {
 }
 
 impl eframe::App for TemplateApp {
-    /// Called by the frame work to save state before shutdown.
+    /// Called by the framework to save state before shutdown.
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         eframe::set_value(storage, eframe::APP_KEY, self);
     }


### PR DESCRIPTION
"frame work" -> "framework"