### PR TITLE
Revert "Update CI deployment"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,14 +111,17 @@ jobs:
         - os: macos-latest
           TARGET: aarch64-apple-darwin
 
-        - os: ubuntu-latest
-          TARGET: aarch64-unknown-linux-gnu
+        - os: macos-latest
+          TARGET: x86_64-apple-darwin
 
         - os: ubuntu-latest
-          TARGET: armv7-unknown-linux-gnueabihf
+          TARGET: arm-unknown-linux-musleabihf
 
         - os: ubuntu-latest
-          TARGET: x86_64-unknown-linux-gnu
+          TARGET: armv7-unknown-linux-musleabihf
+
+        - os: ubuntu-latest
+          TARGET: x86_64-unknown-linux-musl
 
         - os: windows-latest
           TARGET: x86_64-pc-windows-msvc
@@ -129,26 +132,17 @@ jobs:
       run: echo "${{ matrix.TARGET }}"
 
     - uses: actions/checkout@master
-    - name: Install build dependencies - Rustup
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --profile default --target ${{ matrix.TARGET }} -y
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    - uses: actions-rs/toolchain@v1.0.1
+      with:
+        toolchain: stable
+        target: ${{ matrix.TARGET }}
+        override: true
 
-    # For linux, it's necessary to use cross from the git repository to avoid glibc problems
-    # Ref: https://github.com/cross-rs/cross/issues/1510
-    - name: Install cross for linux
-      if: contains(matrix.TARGET, 'linux')
-      run: |
-        cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7
-
-    - name: Install cross for mac and windows
-      if: ${{ !contains(matrix.TARGET, 'linux') }}
-      run: |
-        cargo install cross
-
-    - name: Build
-      run: |
-        cross build --verbose --release --target=${{ matrix.TARGET }}
+    - uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --verbose --release --target=${{ matrix.TARGET }}
 
     - name: Rename
       run: cp target/${{ matrix.TARGET }}/release/eframe_template${{ matrix.EXTENSION }} eframe_template-${{ matrix.TARGET }}${{ matrix.EXTENSION }}


### PR DESCRIPTION
* Reverts emilk/eframe_template#139

This is required to unblock updating to Rust 1.85, which is required by the upcoming egui release:
* https://github.com/emilk/eframe_template/pull/193