### PR TITLE
fix(flake): get channel, components, targets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,20 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
+        
+        rustToolchainToml = fromTOML (builtins.readFile ./rust-toolchain);
+        inherit (rustToolchainToml.toolchain) channel targets components;
+
+        rustToolchain = pkgs.rust-bin.stable.${channel}.default.override {
+          extensions = components;
+          inherit targets;
+        };
+
       in with pkgs; {
         devShells.default = mkShell rec {
           buildInputs = [
             # Rust
-            rust-bin.stable.latest.default
+            rustToolchain
             trunk
 
             # misc. libraries

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -5,6 +5,6 @@
 # to the user in the error, instead of "error: invalid channel name '[toolchain]'".
 
 [toolchain]
-channel = "1.85"  # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
+channel = "1.85.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
from `rust-toolchain` to have as same Rust version etc. installed as *non* Nix users.

```sh
rustc --version
rustc 1.85.0 (4d91de4e4 2025-02-17)
``` 

Note: PATCH version for `channel` is needed here and not an issue as mentioned in #145 (see https://github.com/emilk/eframe_template/issues/145#issuecomment-3089489680).

Closes #183 (not needed anymore)
Closes #148  (not needed anymore)