### PR TITLE
update reflink to Trunk website

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On Fedora Rawhide you need to run:
 
 You can compile your app to [WASM](https://en.wikipedia.org/wiki/WebAssembly) and publish it as a web page.
 
-We use [Trunk](https://trunkrs.dev/) to build for web target.
+We use [Trunk](https://trunk-rs.github.io/trunk/) to build for web target.
 1. Install the required target with `rustup target add wasm32-unknown-unknown`.
 2. Install Trunk with `cargo install --locked trunk`.
 3. Run `trunk serve` to build and serve on `http://127.0.0.1:8080`. Trunk will rebuild automatically if you edit the project.


### PR DESCRIPTION
https://github.com/trunk-rs/trunk/issues/1043

It looks like Trunk lost their hostname and someone used it to advertise some scam.