### PR TITLE
Fix outdated trunk link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On Fedora Rawhide you need to run:
 
 You can compile your app to [WASM](https://en.wikipedia.org/wiki/WebAssembly) and publish it as a web page.
 
-We use [Trunk](https://trunkrs.dev/) to build for web target.
+We use [Trunk](https://trunk-rs.github.io/trunk) to build for web target.
 1. Install the required target with `rustup target add wasm32-unknown-unknown`.
 2. Install Trunk with `cargo install --locked trunk`.
 3. Run `trunk serve` to build and serve on `http://127.0.0.1:8080`. Trunk will rebuild automatically if you edit the project.


### PR DESCRIPTION
Hello,

I was poking around to try and follow the template. I noticed the Trunkrs link now directs to an online casino...

The official trunk-rs/trunk repo has their link as https://trunk-rs.github.io/trunk. I would suggest to replace the link with the github.io or remove the hyperlink entirely. I suggest this change happen as soon as possible.

@emilk 

Have a nice day.